### PR TITLE
ember-try: Add missing `useYarn` flag

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,5 +1,6 @@
 /* eslint-env node */
 module.exports = {
+  useYarn: true,
   scenarios: [
     {
       name: 'ember-lts-2.8',


### PR DESCRIPTION
Looks like I forgot that in #2 because the `ember init` blueprint apparently does not include it 🤔 

/cc @locks @rwjblue 