### PR TITLE
Avoid shipping duplicate implementation.

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,153 +1,160 @@
+import { gte } from 'ember-compatibility-helpers';
 import { guidFor } from '@ember/object/internals';
 import { assert } from '@ember/debug';
+import Ember from 'ember';
 
-/**
+const NEEDS_CUSTOM_ORDERED_SET = gte('3.5.0-alpha.1');
+
+let OrderedSet;
+
+if (NEEDS_CUSTOM_ORDERED_SET) {
+  /**
   @class OrderedSet
   @constructor
-*/
-export default class OrderedSet {
-  constructor() {
-    this.clear();
-  }
+  */
+  OrderedSet = class OrderedSet {
+    constructor() {
+      this.clear();
+    }
 
-  /**
+    /**
     @method create
     @static
     @return {OrderedSet}
-  */
-  static create() {
-    let Constructor = this;
-    return new Constructor();
-  }
+    */
+    static create() {
+      let Constructor = this;
+      return new Constructor();
+    }
 
-  /**
+    /**
     @method clear
-  */
-  clear() {
-    this.presenceSet = Object.create(null);
-    this.list = [];
-    this.size = 0;
-  }
+    */
+    clear() {
+      this.presenceSet = Object.create(null);
+      this.list = [];
+      this.size = 0;
+    }
 
-  /**
+    /**
     @method add
     @param {*} obj
     @param {string} [_guid] (for internal use)
     @return {OrderedSet}
-  */
-  add(obj, _guid) {
-    let guid = _guid || guidFor(obj);
-    let presenceSet = this.presenceSet;
-    let list = this.list;
+    */
+    add(obj, _guid) {
+      let guid = _guid || guidFor(obj);
+      let presenceSet = this.presenceSet;
+      let list = this.list;
 
-    if (presenceSet[guid] !== true) {
-      presenceSet[guid] = true;
-      this.size = list.push(obj);
+      if (presenceSet[guid] !== true) {
+        presenceSet[guid] = true;
+        this.size = list.push(obj);
+      }
+
+      return this;
     }
 
-    return this;
-  }
-
-  /**
+    /**
     @method delete
     @param {*} obj
     @param {string} [_guid] (for internal use)
     @return {Boolean}
-  */
-  delete(obj, _guid) {
-    let guid = _guid || guidFor(obj);
-    let presenceSet = this.presenceSet;
-    let list = this.list;
+    */
+    delete(obj, _guid) {
+      let guid = _guid || guidFor(obj);
+      let presenceSet = this.presenceSet;
+      let list = this.list;
 
-    if (presenceSet[guid] === true) {
-      delete presenceSet[guid];
-      let index = list.indexOf(obj);
-      if (index > -1) {
-        list.splice(index, 1);
+      if (presenceSet[guid] === true) {
+        delete presenceSet[guid];
+        let index = list.indexOf(obj);
+        if (index > -1) {
+          list.splice(index, 1);
+        }
+        this.size = list.length;
+        return true;
+      } else {
+        return false;
       }
-      this.size = list.length;
-      return true;
-    } else {
-      return false;
     }
-  }
 
-  /**
+    /**
     @method isEmpty
     @return {Boolean}
-  */
-  isEmpty() {
-    return this.size === 0;
-  }
+    */
+    isEmpty() {
+      return this.size === 0;
+    }
 
-  /**
+    /**
     @method has
     @param {*} obj
     @return {Boolean}
-  */
-  has(obj) {
-    if (this.size === 0) { return false; }
+    */
+    has(obj) {
+      if (this.size === 0) { return false; }
 
-    let guid = guidFor(obj);
-    let presenceSet = this.presenceSet;
+      let guid = guidFor(obj);
+      let presenceSet = this.presenceSet;
 
-    return presenceSet[guid] === true;
-  }
+      return presenceSet[guid] === true;
+    }
 
-  /**
+    /**
     @method forEach
     @param {Function} fn
     @param self
-  */
-  forEach(fn /*, ...thisArg*/) {
-    assert(`${Object.prototype.toString.call(fn)} is not a function`, typeof fn === 'function')
+    */
+    forEach(fn /*, ...thisArg*/) {
+      assert(`${Object.prototype.toString.call(fn)} is not a function`, typeof fn === 'function')
 
-    if (this.size === 0) { return; }
+      if (this.size === 0) { return; }
 
-    let list = this.list;
+      let list = this.list;
 
-    if (arguments.length === 2) {
-      for (let i = 0; i < list.length; i++) {
-        fn.call(arguments[1], list[i]);
-      }
-    } else {
-      for (let i = 0; i < list.length; i++) {
-        fn(list[i]);
+      if (arguments.length === 2) {
+        for (let i = 0; i < list.length; i++) {
+          fn.call(arguments[1], list[i]);
+        }
+      } else {
+        for (let i = 0; i < list.length; i++) {
+          fn(list[i]);
+        }
       }
     }
-  }
 
-  /**
+    /**
     @method toArray
     @return {Array}
-  */
-  toArray() {
-    return this.list.slice();
-  }
+    */
+    toArray() {
+      return this.list.slice();
+    }
 
-  /**
+    /**
     @method copy
     @return {OrderedSet}
-  */
-  copy() {
-    let Constructor = this.constructor;
-    let set = new Constructor();
+    */
+    copy() {
+      let Constructor = this.constructor;
+      let set = new Constructor();
 
-    set.presenceSet = copyNull(this.presenceSet);
-    set.list = this.toArray();
-    set.size = this.size;
+      set.presenceSet = Object.create(null);
 
-    return set;
+      for (let prop in this.presenceSet) {
+        // hasOwnPropery is not needed because obj is Object.create(null);
+        set.presenceSet[prop] = this.presenceSet[prop];
+      }
+
+      set.list = this.toArray();
+      set.size = this.size;
+
+      return set;
+    }
   }
+} else {
+  OrderedSet = Ember.OrderedSet;
 }
 
-function copyNull(obj) {
-  let output = Object.create(null);
-
-  for (let prop in obj) {
-    // hasOwnPropery is not needed because obj is Object.create(null);
-    output[prop] = obj[prop];
-  }
-
-  return output;
-}
+export default OrderedSet;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,11 @@
 'use strict';
 
 module.exports = {
-  name: '@ember/ordered-set'
+  name: '@ember/ordered-set',
+
+  options: {
+    babel: {
+      loose: true,
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.8.2",
+    "ember-cli-babel": "6.12.0",
     "ember-compatibility-helpers": "^1.0.0-beta.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.8.2"
+    "ember-cli-babel": "^6.8.2",
+    "ember-compatibility-helpers": "^1.0.0-beta.2"
   },
   "devDependencies": {
     "ember-cli": "~3.0.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-shims": "^1.2.0",
+    "ember-cli-uglify": "^2.0.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-load-initializers": "^1.0.0",
     "ember-maybe-import-regenerator": "^0.1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1586,6 +1586,10 @@ commander@^2.6.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
+commander@~2.13.0:
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
+
 common-tags@^1.4.0:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.7.2.tgz#24d9768c63d253a56ecff93845b44b4df1d52771"
@@ -1783,7 +1787,7 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
-debug@^3.0.1:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2183,6 +2187,14 @@ ember-cli@~3.0.0:
     walk-sync "^0.3.0"
     watch-detector "^0.1.0"
     yam "0.0.22"
+
+ember-compatibility-helpers@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0-beta.2.tgz#00cb134af45f9562fa47a23f4da81a63aad41943"
+  dependencies:
+    babel-plugin-debug-macros "^0.1.11"
+    ember-cli-version-checker "^2.0.0"
+    semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.2:
   version "1.1.3"
@@ -4440,7 +4452,7 @@ markdown-it@^8.3.0, markdown-it@^8.3.1:
     mdurl "^1.0.1"
     uc.micro "^1.0.3"
 
-matcher-collection@^1.0.0:
+matcher-collection@^1.0.0, matcher-collection@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.0.5.tgz#2ee095438372cb8884f058234138c05c644ec339"
   dependencies:
@@ -5897,6 +5909,10 @@ source-map@~0.1.x:
   dependencies:
     amdefine ">=0.0.4"
 
+source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+
 sourcemap-validator@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/sourcemap-validator/-/sourcemap-validator-1.0.6.tgz#abd2f1ecdae6a3c46c2c96c5f256705b2147c9c0"
@@ -6337,6 +6353,13 @@ uc.micro@^1.0.1, uc.micro@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
 
+uglify-es@^3.1.3:
+  version "3.3.9"
+  resolved "https://registry.yarnpkg.com/uglify-es/-/uglify-es-3.3.9.tgz#0c1c4f0700bed8dbc124cdb304d2592ca203e677"
+  dependencies:
+    commander "~2.13.0"
+    source-map "~0.6.1"
+
 uglify-js@^2.6:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
@@ -6494,7 +6517,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-walk-sync@0.3.2, walk-sync@^0.3.0, walk-sync@^0.3.1:
+walk-sync@0.3.2, walk-sync@^0.3.0, walk-sync@^0.3.1, walk-sync@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.3.2.tgz#4827280afc42d0e035367c4a4e31eeac0d136f75"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1222,6 +1222,20 @@ broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
     symlink-or-copy "^1.1.8"
     walk-sync "^0.3.0"
 
+broccoli-uglify-sourcemap@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/broccoli-uglify-sourcemap/-/broccoli-uglify-sourcemap-2.0.2.tgz#f4a73112f1f56b46043e2e89cba5ce7762cddeb3"
+  dependencies:
+    broccoli-plugin "^1.2.1"
+    debug "^3.1.0"
+    lodash.defaultsdeep "^4.6.0"
+    matcher-collection "^1.0.5"
+    mkdirp "^0.5.0"
+    source-map-url "^0.4.0"
+    symlink-or-copy "^1.0.1"
+    uglify-es "^3.1.3"
+    walk-sync "^0.3.2"
+
 broccoli-writer@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/broccoli-writer/-/broccoli-writer-0.1.1.tgz#d4d71aa8f2afbc67a3866b91a2da79084b96ab2d"
@@ -2087,6 +2101,13 @@ ember-cli-test-loader@^2.2.0:
   resolved "https://registry.yarnpkg.com/ember-cli-test-loader/-/ember-cli-test-loader-2.2.0.tgz#3fb8d5d1357e4460d3f0a092f5375e71b6f7c243"
   dependencies:
     ember-cli-babel "^6.8.1"
+
+ember-cli-uglify@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-uglify/-/ember-cli-uglify-2.0.2.tgz#12becdaf1a2e6f0cdbd386b1d5f5a2d0540347d3"
+  dependencies:
+    broccoli-uglify-sourcemap "^2.0.1"
+    lodash.defaultsdeep "^4.6.0"
 
 ember-cli-valid-component-name@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,7 +1951,7 @@ electron-to-chromium@^1.3.27:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.3.0:
+ember-cli-babel@6.12.0, ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0, ember-cli-babel@^6.3.0:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.12.0.tgz#3adcdbe1278da1fcd0b9038f1360cb4ac5d4414c"
   dependencies:
@@ -1969,7 +1969,7 @@ ember-cli-babel@^6.0.0-beta.4, ember-cli-babel@^6.10.0, ember-cli-babel@^6.11.0,
     ember-cli-version-checker "^2.1.0"
     semver "^5.4.1"
 
-ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.8.1, ember-cli-babel@^6.8.2:
+ember-cli-babel@^6.0.0-beta.7, ember-cli-babel@^6.8.1:
   version "6.8.2"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-6.8.2.tgz#eac2785964f4743f4c815cd53c6288f00cc087d7"
   dependencies:


### PR DESCRIPTION
Resolves #11.

Leverages `ember-compatibility-helpers` to perform build time `semver.gte` checks (replacing the invocation with static `true` or `false` value which is then removed by uglify during its dead code elimination).

Current module output (after running through a beautifier) for a production build after these changes:

```js
define("@ember/ordered-set/index", ["exports"], function(e) {
    "use strict"
    Object.defineProperty(e, "__esModule", {
        value: !0
    })
    var t = void 0
    t = Ember.OrderedSet, e.default = t
})
```