### PR TITLE
updated ember-compatibility-helpers version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "6.12.0",
-    "ember-compatibility-helpers": "^1.0.0-beta.2"
+    "ember-compatibility-helpers": "^1.0.0"
   },
   "devDependencies": {
     "ember-cli": "~3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2122,6 +2122,13 @@ ember-cli-version-checker@^2.0.0, ember-cli-version-checker@^2.1.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.2.tgz#305ce102390c66e4e0f1432dea9dc5c7c19fed98"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-3.0.0.tgz#3d44be3ea88345d4d03c95453eb3527b15dbaeb2"
@@ -2209,12 +2216,12 @@ ember-cli@~3.0.0:
     watch-detector "^0.1.0"
     yam "0.0.22"
 
-ember-compatibility-helpers@^1.0.0-beta.2:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0-beta.2.tgz#00cb134af45f9562fa47a23f4da81a63aad41943"
+ember-compatibility-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.0.0.tgz#616b22d2e14b4c6a1f4441e5390a49abf52b3c68"
   dependencies:
     babel-plugin-debug-macros "^0.1.11"
-    ember-cli-version-checker "^2.0.0"
+    ember-cli-version-checker "^2.1.1"
     semver "^5.4.1"
 
 ember-disable-prototype-extensions@^1.1.2:


### PR DESCRIPTION
This package is now out of beta. I'm proposing to use the v1 stable and up going forward.

Thanks!