### PR TITLE
avoid ordered-set deprecation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -154,7 +154,7 @@ if (NEEDS_CUSTOM_ORDERED_SET) {
     }
   }
 } else {
-  OrderedSet = Ember.OrderedSet;
+  OrderedSet = Ember.__OrderedSet__ || Ember.OrderedSet;
 }
 
 export default OrderedSet;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -41,6 +41,8 @@ module.exports = function(environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+
+    ENV.EmberENV.RAISE_ON_DEPRECATION = true;
   }
 
   if (environment === 'production') {


### PR DESCRIPTION
This fixes https://github.com/emberjs/ember-ordered-set/issues/19 and depends on https://github.com/emberjs/ember.js/pull/16709. 