### PR TITLE
Update Ember.js compatibility info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,8 @@ jobs:
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=ember-lts-3.16
     - env: EMBER_TRY_SCENARIO=ember-lts-3.20
     - env: EMBER_TRY_SCENARIO=ember-release

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ class introduced in ES2015.
 Compatibility
 ------------------------------------------------------------------------------
 
-* Ember.js v3.16 or above
+* Ember.js v3.8 or above
 * Ember CLI v2.13 or above
 * Node.js v10 or above
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,6 +7,22 @@ module.exports = async function() {
     useYarn: true,
     scenarios: [
       {
+        name: 'ember-lts-3.8',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.8.0'
+          }
+        }
+      },
+      {
+        name: 'ember-lts-3.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.12.0'
+          }
+        }
+      },
+      {
         name: 'ember-lts-3.16',
         npm: {
           devDependencies: {


### PR DESCRIPTION
Add Ember.js 3.8 and 3.12 to ember-try and update min version in README.md